### PR TITLE
Spell CO2 with an "O" instead of a zero

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -21,6 +21,6 @@
     - local: open_llm_leaderboard/normalization
       title: Scores Normalization
     - local: open_llm_leaderboard/emissions
-      title: C02 calculation
+      title: CO2 calculation
     - local: open_llm_leaderboard/archive
       title: Archived versions

--- a/docs/source/en/open_llm_leaderboard/emissions.md
+++ b/docs/source/en/open_llm_leaderboard/emissions.md
@@ -1,6 +1,6 @@
-# C02 calculation
+# CO2 calculation
 
-## Function for C02 calculation
+## Function for CO2 calculation
 
 To calculate `CO₂ Emissions for Evaluation (kg)` value, we use the following function. You can try to reproduce it yourself:
 


### PR DESCRIPTION
The "O" in "CO2" stands for "Oxygen", so it should be an "O", not a zero.